### PR TITLE
otp-24

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 24.1.2
+elixir 1.12.3-otp-24

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # signal_handler
 
-`System.SignalHandler` is an Elixir application containing a NIF module. This NIF can register itself as the recipient of arbitrary POSIX signals directed at the Erlang node, and will then hand them off as messages to Erlang-land.
+`SignalHandler` is an Elixir application containing a NIF module. This NIF can register itself as the recipient of arbitrary POSIX signals directed at the Erlang node, and will then hand them off as messages to Erlang-land.
 
-**Important note:** `System.SignalHandler` runs in the context of an ERTS scheduler thread, so unexpected behavior could occur if you were able to override signal registrations used by ERTS. You can see which signals these are using `System.SignalHandler.erts_reserved_signals/0`. It is not recommended to override these signals, but `System.SignalHandler` does nothing to stop you from doing so.
+**Important note:** `SignalHandler` runs in the context of an ERTS scheduler thread, so unexpected behavior could occur if you were able to override signal registrations used by ERTS. You can see which signals these are using `SignalHandler.erts_reserved_signals/0`. It is not recommended to override these signals, but `SignalHandler` does nothing to stop you from doing so.
 
 ## Configuration
 
@@ -16,7 +16,7 @@ Then, in `your_handler.ex`:
 
 ```elixir
 defmodule YourHandler do
-  use System.SignalHandler
+  use SignalHandler
 
   handle :winch do
     # oh hey the terminal size changed
@@ -24,30 +24,30 @@ defmodule YourHandler do
 end
 ```
 
-By default, `modules` is `[System.SignalHandler.GracefulShutdown]`, which simply maps `SIGTERM` to `:init.stop()`.
+By default, `modules` is `[SignalHandler.GracefulShutdown]`, which simply maps `SIGTERM` to `:init.stop()`.
 
 ## Usage
 
 Installing a predefined signal-handler module at runtime:
 
 ```elixir
-System.SignalHandler.install(YourHandler)
+SignalHandler.install(YourHandler)
 ```
 
 Registering a one-off signal handler at runtime:
 
 ```elixir
-System.SignalHandler.register(:term, &:init.stop/0)
+SignalHandler.register(:term, &:init.stop/0)
 ```
 
 Unregistering a signal:
 
 ```elixir
-System.SignalHandler.unregister(:term)
+SignalHandler.unregister(:term)
 ```
 
 Getting the state of all known signals:
 
 ```elixir
-System.SignalHandler.signals()
+SignalHandler.signals()
 ```

--- a/lib/signal_handler.ex
+++ b/lib/signal_handler.ex
@@ -7,7 +7,7 @@ defmodule SignalHandler do
     import Supervisor.Spec, warn: false
 
     children = [
-      {SignalHandler.Listener, []}
+      SignalHandler.Listener
     ]
 
     opts = [strategy: :one_for_one, name: SignalHandler.Supervisor]

--- a/lib/signal_handler.ex
+++ b/lib/signal_handler.ex
@@ -1,4 +1,4 @@
-defmodule System.SignalHandler do
+defmodule SignalHandler do
   require Logger
 
   use Application
@@ -7,10 +7,10 @@ defmodule System.SignalHandler do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(System.SignalHandler.Listener, [])
+      {SignalHandler.Listener, []}
     ]
 
-    opts = [strategy: :one_for_one, name: System.SignalHandler.Supervisor]
+    opts = [strategy: :one_for_one, name: SignalHandler.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
@@ -44,7 +44,7 @@ defmodule System.SignalHandler do
 
   defmacro __using__(_opts) do
     quote do
-      import System.SignalHandler, only: [handle: 2]
+      import SignalHandler, only: [handle: 2]
     end
   end
 

--- a/lib/signal_handler/graceful_shutdown.ex
+++ b/lib/signal_handler/graceful_shutdown.ex
@@ -1,7 +1,7 @@
-defmodule System.SignalHandler.GracefulShutdown do
-  use System.SignalHandler
+defmodule SignalHandler.GracefulShutdown do
+  require SignalHandler
 
-  handle :term do
+  SignalHandler.handle :term do
     :init.stop()
   end
 end

--- a/lib/signal_handler/listener.ex
+++ b/lib/signal_handler/listener.ex
@@ -10,6 +10,13 @@ defmodule SignalHandler.Listener do
     :ok = :erlang.load_nif(nif_path, 0)
   end
 
+  def child_spec(_opts) do
+    %{
+      id: make_ref(),
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
   def start_link do
     GenServer.start_link(__MODULE__, [])
   end

--- a/lib/signal_handler/listener.ex
+++ b/lib/signal_handler/listener.ex
@@ -1,4 +1,4 @@
-defmodule System.SignalHandler.Listener do
+defmodule SignalHandler.Listener do
   require Logger
   use Bitwise
 
@@ -26,7 +26,7 @@ defmodule System.SignalHandler.Listener do
     Task.start_link(fn ->
       configured_handler_modules =
         Application.get_env(:signal_handler, :modules, [
-          System.SignalHandler.GracefulShutdown
+          SignalHandler.GracefulShutdown
         ])
 
       configured_handler_modules

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule System.SignalHandler.Mixfile do
     [
       app: :signal_handler,
       version: "0.1.1",
-      elixir: "~> 1.3",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       compilers: [:signal_handler_makefile, :elixir, :app],

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Compile.SignalHandlerMakefile do
   end
 end
 
-defmodule System.SignalHandler.Mixfile do
+defmodule SignalHandler.Mixfile do
   use Mix.Project
 
   def project do
@@ -49,7 +49,7 @@ defmodule System.SignalHandler.Mixfile do
 
   def application do
     [
-      mod: {System.SignalHandler, []},
+      mod: {SignalHandler, []},
       applications: [:logger]
     ]
   end

--- a/src/signal_handler_nif.c
+++ b/src/signal_handler_nif.c
@@ -167,4 +167,4 @@ static ErlNifFunc nif_funcs[] = {
   {"unregister", 1, unregister_signal}
 };
 
-ERL_NIF_INIT(Elixir.System.SignalHandler.Listener, nif_funcs, NULL, NULL, NULL, NULL)
+ERL_NIF_INIT(Elixir.SignalHandler.Listener, nif_funcs, NULL, NULL, NULL, NULL)


### PR DESCRIPTION
This was not running on OTP 24 (and probably earlier versions) with the following error:

```
== Compilation error in file lib/signal_handler/graceful_shutdown.ex ==
** (CompileError) lib/signal_handler/graceful_shutdown.ex:4: undefined function handle/2
```

Everything now works, and a warning was fixed.